### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/code/Block/Adminhtml/Sales/Order/Grid.php
+++ b/code/Block/Adminhtml/Sales/Order/Grid.php
@@ -108,7 +108,7 @@ class Cm_OrderProducts_Block_Adminhtml_Sales_Order_Grid extends Mage_Adminhtml_B
                 'index'     => 'skus',
                 'type'      => 'text',
                 'filter_index' => 'soi.'. Mage::getStoreConfig(self::XML_PATH_FILTER_COLUMN),
-                'sortable'  => FALSE,
+                'sortable'  => false,
                 'renderer'  => 'Cm_OrderProducts_Block_Adminhtml_Sales_Order_Grid_Renderer_Products',
                 'render_column' =>  Mage::getStoreConfig(self::XML_PATH_RENDER_COLUMN),
             ), 'shipping_name');


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!