### PR TITLE
Add .gitignore file with .basedir modman file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.basedir


### PR DESCRIPTION
Modman allows to deploy the imported module in a sub-directory of the project root. The sub-directory name is stored in .basedir file. This file will vary between projects and therefore shouldn't be stored in git repository. Adding it to .gitignore file by default will make git status output clearer.